### PR TITLE
Fix file paths and imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ Clone the repository to your device
 Use npm to install all dependencies (project is built using Vite)
 
     npm i
-To locally host the site for testing:
+To locally host the site while developing:
 
     npm run dev
-The default local URL to the site should be **http://localhost:5173/**
+The default local URL to the dev site should be **http://localhost:5173/milpitashacks-25/**
+
+Before pushing, build the project and test the output:
+
+    npm run build
+    npm run preview
+The default local URL to the built site should be **http://localhost:4173/milpitashacks-25/**

--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
     <meta name="description" content="Join Milpitas Hacks 2025 for an unforgettable hackathon experience at Milpitas High School! Explore innovation, prizes, and more." />
     <title>Milpitas Hacks 2025</title>
     <link rel="stylesheet" href="src/style.css" />
-    <script src="src/main.js" defer></script>
+    <script type="module" src="src/main.js" defer></script>
   </head>
   <body>
     <header class="hero-header">
       <nav class="hero-bar">
         <!-- Top logo + menu items -->
         <div class="logo-container">
-          <img src="/public/Milpitas-Hacks-MH-White.png" alt="Milpitas Hacks Logo" class="mh-logo" loading="lazy" />
+          <img src="/Milpitas-Hacks-MH-White.png" alt="Milpitas Hacks Logo" class="mh-logo" loading="lazy" />
         </div>
 
         <div class="burger-menu" role="button" aria-label="Menu Toggle" aria-expanded="false">
@@ -36,7 +36,7 @@
       <div class="hero-content">
         <!-- Logo, location, and date -->
         <div class="main-logo-container">
-          <img src="/public/Milpitas-Hacks-Main-White.png" alt="Milpitas Hacks Main Event Logo" class="main-logo" loading="lazy" />
+          <img src="/Milpitas-Hacks-Main-White.png" alt="Milpitas Hacks Main Event Logo" class="main-logo" loading="lazy" />
           <div class="location-date-container">
             <p class="location">Milpitas High School</p>
             <p class="date">May 31, 2025</p>

--- a/src/style.css
+++ b/src/style.css
@@ -13,7 +13,7 @@ header.hero-header {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    background-image: url('/public/background.jpg');
+    background-image: url('/background.jpg');
     background-size: cover;  
     background-position: center;
     background-color: #1a1a1a;


### PR DESCRIPTION
Removed `public/` from image imports, as Vite automatically moves files under that directory to the root directory during the build project. Also, added `type="module"` to the main.js import statement to fix a build error.